### PR TITLE
Initial Error

### DIFF
--- a/vue/src/components/BirdOfTheDay.vue
+++ b/vue/src/components/BirdOfTheDay.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="dailyBird">
-    <iframe
+    <iframe v-if="error == ''"
       width="800"
       height="578"
       v-bind:src="imgUrl + '/embed/800'"
@@ -8,6 +8,7 @@
       allowfullscreen
       style="width: 800px"
     ></iframe>
+    <p v-else>{{ this.error }}</p>
   </div>
 </template>
 


### PR DESCRIPTION
There was a problem out the gate with the front end provided by Tech Elevator. 

It attempts to route an iframe to the backend, but we hadn't actually written that backend endpoint yet, so it winds up calling the iframe `src` to `"/embed/800"` (the line in code is `v-bind:src="imgUrl + '/embed/800'"`). 

This just routes it right back to the `Home.vue` page via the `router/index.js` route. Here is that route, for helpful context.
```javascript
{
      path: '/',
      name: 'home',
      alias: '/login',
      component: Home,
      meta: {
        requiresAuth: false
      }
    },
```
Since that route (`"/"`) takes no parameters, it just throws away the parameter "embed/800" and reroutes to a blank homepage.

This should have been fine because the creator wrote a catch to handle an error from the backend endpoint (such as a 404: "what endpoint?"). 
```javascript
.catch((err) => {
        this.error=err + " problem generating a random bird!";
      });
```

Unfortunately in the HTML, however, it never calls on the `error` message just created and it doesn't include a conditional to render that error instead of the iframe element.

We're lucky this didn't continue attempting to get the iframe into an infinity loop. (App.vue renders MainContent.vue which renders BirdOfTheDay.vue which renders the iframe which renders App.vue renders MainContent.vue which renders BirdOfTheDay.vue which renders the iframe which renders....etc)

The code this PR adds to the project is just the error handling that slipped the creator's mind. In other words, this code lets the front end code see the backend say "Oh no! We have no birds." and be smart enough to just say, "Oops, sorry user, this one didn't work out, here's what the backend said the cause was."